### PR TITLE
Support other Override locations in update trust script

### DIFF
--- a/autopkg-scripts/autopkg-update-trust-info-recipe-list.sh
+++ b/autopkg-scripts/autopkg-update-trust-info-recipe-list.sh
@@ -77,7 +77,7 @@ recipe_format="yaml"
 pull_parents=0
 verify_only=0
 verbosity=""
-RECIPE_OVERRIDE_DIR="${HOME}/Library/AutoPkg/RecipeOverrides"
+RECIPE_OVERRIDE_DIR=$(defaults read com.github.autopkg RECIPE_OVERRIDE_DIRS)
 AUTOPKG="/usr/local/bin/autopkg"
 AUTOPKG_PREFS="$HOME/Library/Preferences/com.github.autopkg.plist"
 


### PR DESCRIPTION
Currently, the script to update trust info hardcodes the RecipeOverrides dir to ~/Library/AutoPkg/RecipeOverrides. In setups where the AutoPkg preferences specify a different location for RecipeOverrides (via RECIPE_OVERRIDE_DIRS), it should be honoured. This PR assumes that RECIPE_OVERRIDE_DIRS is a string (not an array, which is supported by AutoPkg but highly uncommon). This does not account for the case where the prefs supplied by the user (`--prefs`) have specified another RecipeOverrides directory (but then again, neither does the current script as far as I can tell).